### PR TITLE
Use the package installation scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN vca-install-package \
 
 # Grab the VCA CI Scripts
 RUN vca-install-package wget xz-utils && \
-  wget https://tool-chain.vcatechnology.com/release/vca-tool-chain-ci-scripts-latest.tar.xz && \
+  wget -q https://tool-chain.vcatechnology.com/release/vca-tool-chain-ci-scripts-latest.tar.xz && \
   tar -Jxf vca-tool-chain-ci-scripts-latest.tar.xz -C / && \
   rm vca-tool-chain-ci-scripts-latest.tar.xz && \
   vca-uninstall-package wget xz-utils

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,27 @@
-FROM vcatechnology/linux-mint:18
+FROM vcatechnology/linux-mint
 MAINTAINER VCA Technology <developers@vcatechnology.com>
 
 RUN echo 'APT::Update::Post-Invoke-Success {"touch /var/lib/apt/periodic/update-success-stamp 2>/dev/null || true";};' > /etc/apt/apt.conf.d/15update-stamp
 
 # Install useful packages
-RUN apt-get install -y \
+RUN vca-install-package \
   python \
   git \
   openssh-client \
   sudo
 
-# grab the VCA CI Scripts
-RUN apt-get install -y wget xz-utils && \
+# Grab the VCA CI Scripts
+RUN vca-install-package wget xz-utils && \
   wget https://tool-chain.vcatechnology.com/release/vca-tool-chain-ci-scripts-latest.tar.xz && \
   tar -Jxf vca-tool-chain-ci-scripts-latest.tar.xz -C / && \
   rm vca-tool-chain-ci-scripts-latest.tar.xz && \
-  apt-get remove -y wget xz-utils
+  vca-uninstall-package wget xz-utils
 
-# create a build-server user with sudo permissions & no password
+# Create a build-server user with sudo permissions & no password
 RUN useradd -ms /bin/bash build-server && \
     echo "build-server ALL=(root) NOPASSWD:ALL" | tee -a /etc/sudoers.d/build-server && \
     chmod 0440 /etc/sudoers.d/build-server
 
-# set the build-server user as default
+# Set the build-server user as default
 USER build-server
 WORKDIR /home/build-server


### PR DESCRIPTION
Use the optimal package installation/uninstallation scripts to keep the image
size as small as possible

Requires [vcatechnology/docker-linux-mint!1](https://github.com/vcatechnology/docker-linux-mint/pull/1)